### PR TITLE
Replace atomic x86 ASM code with GCC atomic-builtins.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+{
+  "language": "cpp",
+  "os": [
+    "linux"
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
-{
-  "language": "cpp",
-  "os": [
-    "linux"
-  ]
-}
+language: c
+
+arch:
+  - amd64
+  - arm64
+
+script: 
+  - cd build && cmake ../ && make
+  - ./tars2node
+  
+#before_install：install 阶段之前执行
+#before_script：script 阶段之前执行
+#after_failure：script 阶段失败时执行
+#after_success：script 阶段成功时执行
+#before_deploy：deploy 步骤之前执行
+#after_deploy：deploy 步骤之后执行
+#after_script：script 阶段之后执行
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(IDL_TYPE "Tars")
 set(PROTOCOL_NAME "Tup")
 
 # flag
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -O2 -Wall -Wno-sign-compare -Wno-unused-result -static")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -O2 -Wall -Wno-sign-compare -Wno-unused-result")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O2 -Wall -static")
 
 # define

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tars2Node
 
+[![Build Status](https://travis-ci.org/LyleLee/tars2node.svg?branch=master)](https://travis-ci.org/LyleLee/tars2node)
+
 `tars2node` 可以将 Tars IDL 定义文件转换为 JavaScript 语言所使用的版本，结合 [@tars/stream](https://www.npmjs.com/package/@tars/stream) 模块执行编解码操作。
 
 如您有 Tars RPC 需求可结合 [@tars/rpc](https://www.npmjs.com/package/@tars/rpc) 模块进行调用。

--- a/third_partly/util/include/util/tc_atomic.h
+++ b/third_partly/util/include/util/tc_atomic.h
@@ -137,10 +137,7 @@ public:
      */
     void inc_fast()
     {
-        __asm__ __volatile__(
-            TARS_LOCK "incl %0"
-            :"=m" (_value.counter)
-            :"m" (_value.counter));
+	__sync_add_and_fetch(&_value.counter,1);
     }
 
     /**
@@ -150,14 +147,7 @@ public:
      */
     bool dec_and_test()
     {
-        unsigned char c;
-
-        __asm__ __volatile__(
-            TARS_LOCK "decl %0; sete %1"
-            :"=m" (_value.counter), "=qm" (c)
-            :"m" (_value.counter) : "memory");
-
-        return c != 0;
+	return (0 == __sync_sub_and_fetch(&_value.counter,1));
     }
 
     /**
@@ -177,13 +167,7 @@ protected:
      */
     int add_and_return(int i)
     {
-        /* Modern 486+ processor */
-        int __i = i;
-        __asm__ __volatile__(
-            TARS_LOCK "xaddl %0, %1;"
-            :"=r"(i)
-            :"m"(_value.counter), "0"(i));
-        return i + __i;
+	return (__sync_add_and_fetch(&_value.counter,i));
     }
 
 protected:


### PR DESCRIPTION
GCC builtin provide a series of function for atomic add/sub.
Using those function make code portable for ARM machine.

Reference:
https://gcc.gnu.org/onlinedocs/gcc-4.1.2/gcc/Atomic-Builtins.html

I am able to use this PR to compile tar2node on my ARM server.